### PR TITLE
Fix: replacing prohibited characters on page title when save pdf

### DIFF
--- a/src/main/java/dev/botcity/framework/bot/WebBot.java
+++ b/src/main/java/dev/botcity/framework/bot/WebBot.java
@@ -892,7 +892,11 @@ public class WebBot {
      */
     @SneakyThrows
     public String printPdf(String path, Map<String, Object> printOptions) {
-        String pgTitle = pageTitle().isEmpty() ? "document" : pageTitle();
+        String pgTitle = (pageTitle().isEmpty() ? "document" : pageTitle())
+                .replaceAll("[\\\\\":<>*?/|]+", "_") // replacing prohibited characters in file names
+                .replaceAll(" +", " ") // remove multiple spaces
+                .trim();
+
         int timeout = 60_000;
         String defaultPath = Paths.get(this.downloadPath, pgTitle + ".pdf").toString();
 


### PR DESCRIPTION
Fixes #19 

# Test
HTML sample

```html
<!DOCTYPE html>
<html lang="pt-br">
<head>
    <meta charset="UTF-8">
    <title>(a # b% c& d{ e} f\ g$ h! i' j" k: l@ m< n> o* p? q/ r+ s` t| u=)</title>
</head>
<body>
<h1>Hello</h1>
</body>
</html>
```